### PR TITLE
Fixed orphaned change event listeners

### DIFF
--- a/src/components/AuthenticatedApp.jsx
+++ b/src/components/AuthenticatedApp.jsx
@@ -17,7 +17,8 @@ export default class AuthenticatedApp extends React.Component {
   }
 
   componentDidMount() {
-    LoginStore.addChangeListener(this._onChange.bind(this));
+    this.changeListener = this._onChange.bind(this);
+    LoginStore.addChangeListener(this.changeListener);
   }
 
   _onChange() {
@@ -25,7 +26,7 @@ export default class AuthenticatedApp extends React.Component {
   }
 
   componentWillUnmount() {
-    LoginStore.removeChangeListener(this._onChange.bind(this));
+    LoginStore.removeChangeListener(this.changeListener);
   }
 
   render() {

--- a/src/components/AuthenticatedComponent.jsx
+++ b/src/components/AuthenticatedComponent.jsx
@@ -23,7 +23,8 @@ export default (ComposedComponent) => {
     }
 
     componentDidMount() {
-      LoginStore.addChangeListener(this._onChange.bind(this));
+      this.changeListener = this._onChange.bind(this);
+      LoginStore.addChangeListener(this.changeListener);
     }
 
     _onChange() {
@@ -31,7 +32,7 @@ export default (ComposedComponent) => {
     }
 
     componentWillUnmount() {
-      LoginStore.removeChangeListener(this._onChange.bind(this));
+      LoginStore.removeChangeListener(this.changeListener);
     }
 
     render() {


### PR DESCRIPTION
As implemented, it seems like EventEmitter.removeListener wasn't matching any listeners.
This had react warning about calling setState on unmounted components if users would login/out multiple times.
- Added a new instance variable, changeListener to components to store reference to change callbacks.
- Used this reference in removeListener.
