### PR TITLE
Make the dispatch before transitioning to an authenticated component

### DIFF
--- a/src/actions/LoginActions.js
+++ b/src/actions/LoginActions.js
@@ -5,18 +5,18 @@ import RouterContainer from '../services/RouterContainer'
 export default {
   loginUser: (jwt) => {
     var savedJwt = localStorage.getItem('jwt');
-
+    
+    AppDispatcher.dispatch({
+      actionType: LOGIN_USER,
+      jwt: jwt
+    });
+    
     if (savedJwt !== jwt) {
       var nextPath = RouterContainer.get().getCurrentQuery().nextPath || '/';
 
       RouterContainer.get().transitionTo(nextPath);
       localStorage.setItem('jwt', jwt);
     }
-
-    AppDispatcher.dispatch({
-      actionType: LOGIN_USER,
-      jwt: jwt
-    });
   },
   logoutUser: () => {
     RouterContainer.get().transitionTo('/login');


### PR DESCRIPTION
Suppose "Dashboard" is an authenticated component. Suppose the user has not authenticated and attempts to go to `example.com/dashboard`. The code will correctly kick them to `example.com/login?nextPath=%2Fdashboard`. 

Once they login successfully, `RouterContainer.get().transitionTo(nextPath)` eventually runs. This triggers the following code in in `AuthenticatedComponent.jsx` to run:

```
    static willTransitionTo(transition) {
      if (!LoginStore.isLoggedIn()) {
        transition.redirect('/login', {}, {'nextPath' : transition.path});
      }
    }
```

The `if` condition will be true because the dispatcher has not updated the store yet. The net effect is the transition to "example.com/dashboard" will not occur.

I believe the solution is to move the dispatcher before the `transitionTo` statement. I've made this change on my project and it works as expected.
